### PR TITLE
fixed wrong time of MultiLevelLaserScans

### DIFF
--- a/tasks/MarsRotatingLaserRangeFinder.cpp
+++ b/tasks/MarsRotatingLaserRangeFinder.cpp
@@ -80,6 +80,7 @@ void MarsRotatingLaserRangeFinder::updateHook()
     
     if(_laser_scans.connected() && mSensor->getMultiLevelLaserScan(mScan)) {
         std::cout << "Write mlls" << std::endl;
+        mScan.time = getTime();
         _laser_scans.write(mScan);
     }
 }


### PR DESCRIPTION
Inside the simulator base::time::now is used for
setting the time of the scan. This is wrong, as
the simulation time differs from real time.
This had a great impact as the stream aggregator
started dropping samples in every tasks that was
processing the MLLSs.
