### PR TITLE
Rely on mars libraries to propagate the required Qt Version.

### DIFF
--- a/mars.orogen
+++ b/mars.orogen
@@ -7,8 +7,6 @@ using_library "main_gui", :typekit => false
 using_library "mars_sim", :typekit => false
 using_library "lib_manager", :typekit => false
 using_library "mars_graphics", :typekit => false
-using_library "QtCore", :typekit => false
-using_library "QtGui", :typekit => false
 
 import_types_from "tasks/MarsControl.hpp"
 import_types_from "servoTypes.hpp"

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -20,7 +20,11 @@
 
 #include <lib_manager/LibManager.hpp>
 #include <QApplication>
+#if QT_VERSION >= 0x050000
+#include <QStyleFactory>
+#else
 #include <QPlastiqueStyle>
+#endif
 
 #include <base/logging.h>
 
@@ -112,7 +116,17 @@ void* Task::startTaskFunc(void* argument)
     if(!Task::getTaskInterface()->app){
         //Initialize Qapplication only once! and keep the instance
         Task::getTaskInterface()->app = new QApplication(argc, argv);
+#if QT_VERSION >= 0x050000
+        QStyle* style = QStyleFactory::create("plastique");
+        if(style)
+        {
+            Task::getTaskInterface()->app->setStyle(style);
+        } else {
+            LOG_WARN_S << "QStyle 'plastique' is not available";
+        }
+#else
         Task::getTaskInterface()->app->setStyle(new QPlastiqueStyle);
+#endif
     }
 
     setlocale(LC_ALL,"C");


### PR DESCRIPTION
Depends on rock-simulation/mars#21
Since Qt5 changed the way of setting the QStyle for an application this has to be fixed here as well.