### PR TITLE
use GraphicsManagerInterface instead of GraphicsManager

### DIFF
--- a/mars.orogen
+++ b/mars.orogen
@@ -3,10 +3,8 @@ name 'mars'
 using_library "mars_interfaces", :typekit => false
 using_library "mars_gui", :typekit => false
 using_library "mars_app", :typekit => false
-using_library "main_gui", :typekit => false
 using_library "mars_sim", :typekit => false
 using_library "lib_manager", :typekit => false
-using_library "mars_graphics", :typekit => false
 
 import_types_from "tasks/MarsControl.hpp"
 import_types_from "jointTypes.hpp"

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -10,7 +10,8 @@
 #include <mars/main_gui/MainGUI.h>
 #include <mars/main_gui/GuiInterface.h>
 #include <mars/cfg_manager/CFGManagerInterface.h>
-#include <mars/graphics/GraphicsManager.h>
+#include <mars/interfaces/graphics/GraphicsManagerInterface.h>
+//#include <mars/graphics/GraphicsManager.h>
 #include <mars/app/GraphicsTimer.h>
 #include <mars/interfaces/sim/NodeManagerInterface.h>
 
@@ -218,7 +219,7 @@ void* Task::startTaskFunc(void* argument)
         mars->simulatorInterface->getControlCenter()->cfg->setPropertyValue("Simulator", "realtime calc", "value", marsArguments->realtime_calc);
     }
 
-    mars->marsGraphics = libManager->getLibraryAs<mars::graphics::GraphicsManager>("mars_graphics");
+    mars->marsGraphics = libManager->getLibraryAs<mars::interfaces::GraphicsManagerInterface>("mars_graphics");
 
     // Synchronize with configureHook
     marsArguments->initialized = true;

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -19,13 +19,10 @@ namespace mars{
     namespace interfaces{
         class SimulatorInterface;
         class PluginInterface;
+        class GraphicsManagerInterface;
     };
     namespace app{
         class GraphicsTimer;
-    };
-
-    namespace graphics{
-        class GraphicsManager;
     };
 };
 
@@ -109,7 +106,7 @@ namespace mars {
 
         // GraphicsTimer will be later called with the marsGraphics reference
         // which can be also NULL for a disabled gui
-        mars::graphics::GraphicsManager* marsGraphics;
+        mars::interfaces::GraphicsManagerInterface* marsGraphics;
         
         virtual bool setSim_step_size(double value);
         virtual bool setGravity(::base::Vector3d const & value);


### PR DESCRIPTION
allows to use "alternate" implementations og the manager

also removed duplicate "using_library "main_gui", :typekit => false"