### PR TITLE
Calculate and write the realtime factor

### DIFF
--- a/mars.orogen
+++ b/mars.orogen
@@ -112,6 +112,10 @@ task_context "Task" do
 
         output_port('time', 'double')
         output_port('simulated_time', '/base/Time')
+        output_port('system_time', '/base/Time')
+        output_port('loop_time_real', 'double')
+        output_port('loop_time_sim', 'double')
+        output_port('realtime_factor', 'double')
 
         port_driven 'control_action'
 

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -601,7 +601,18 @@ void Task::receiveData(
         const data_broker::DataPackage& package,
         int id)
 {
-    _simulated_time.write(base::Time::fromMilliseconds(simulatorInterface->getTime()));
+    base::Time simtime = base::Time::fromMilliseconds(simulatorInterface->getTime());
+    base::Time systemtime = base::Time::now();
+    _simulated_time.write(simtime);
+    _system_time.write(systemtime);
+    double realdiff = (systemtime - lastSimUpdateSystemTime).toSeconds();
+    double simdiff = (simtime - lastSimUpdateSimTime).toSeconds();
+    _loop_time_real.write(realdiff);
+    _loop_time_sim.write(simdiff);
+    _realtime_factor.write(simdiff/realdiff);
+
+    lastSimUpdateSimTime = simtime;
+    lastSimUpdateSystemTime = systemtime;
 }
 
 bool Task::setGravity_internal(::base::Vector3d const & value){

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -78,6 +78,9 @@ namespace mars {
 	pthread_t thread_info; 
 	static lib_manager::LibManager* libManager;
 
+    base::Time lastSimUpdateSimTime;
+    base::Time lastSimUpdateSystemTime;
+
         mars::interfaces::PluginInterface* multisimPlugin;
 
         int getOptionCount(const std::vector<Option>& options);


### PR DESCRIPTION
Calculate and write the realtime factor of the mars::Task. 

Calculated by taking the time diff of the real time and the diff of the simulation time.
Also prints the loop time of the sim, to easily find the calc_ms property from rock-display

