### PR TITLE
add `smurf_loader` dependency to orogen file

### DIFF
--- a/mars.orogen
+++ b/mars.orogen
@@ -4,6 +4,7 @@ using_library "mars_interfaces", :typekit => false
 using_library "mars_gui", :typekit => false
 using_library "mars_app", :typekit => false
 using_library "mars_sim", :typekit => false
+using_library "mars_smurf_loader", :typekit => false
 using_library "lib_manager", :typekit => false
 using_library "configmaps", :typekit => false
 

--- a/tasks/CMakeLists.txt
+++ b/tasks/CMakeLists.txt
@@ -3,10 +3,6 @@ find_package( Boost COMPONENTS filesystem)
 find_package(lib_manager)
 setup_qt()
 
-pkg_check_modules(PKGCONFIG REQUIRED
-    mars_smurf_loader
-)
-
 include(marsTaskLib)
 ADD_LIBRARY(${MARS_TASKLIB_NAME} SHARED
     ${MARS_TASKLIB_SOURCES})


### PR DESCRIPTION
This is apparantly needed to find the library properly. The explicit lookup with pkg-config doesn't seem to be necessary.

@hwiedDFKI 