### PR TITLE
Add qt5 modules

### DIFF
--- a/tasks/CMakeLists.txt
+++ b/tasks/CMakeLists.txt
@@ -9,6 +9,10 @@ ADD_LIBRARY(${MARS_TASKLIB_NAME} SHARED
 add_dependencies(${MARS_TASKLIB_NAME}
     regen-typekit)
 
+if (${USE_QT5})
+qt5_use_modules(${MARS_TASKLIB_NAME} Xml Widgets)
+endif (${USE_QT5})
+
 TARGET_LINK_LIBRARIES(${MARS_TASKLIB_NAME}
     ${OrocosRTT_LIBRARIES}
     ${Boost_FILESYSTEM_LIBRARY}


### PR DESCRIPTION
This fetches the qt5 dependencies when qt5 is enabled to match what the suppliers of the headers do, same as is done for qt4.